### PR TITLE
fix: Fix sql import with large query

### DIFF
--- a/parent/qubership-atp-tdm-parent-java/pom.xml
+++ b/parent/qubership-atp-tdm-parent-java/pom.xml
@@ -65,26 +65,6 @@
                 <version>2.9.11</version>
             </dependency>
             <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-web</artifactId>
-                <version>5.3.34</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.security</groupId>
-                <artifactId>spring-security-core</artifactId>
-                <version>5.7.12</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-webmvc</artifactId>
-                <version>5.3.31</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-security-core</artifactId>
-                <version>5.7.12</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
                 <version>3.2.2</version>

--- a/qubership-atp-tdm-backend/pom.xml
+++ b/qubership-atp-tdm-backend/pom.xml
@@ -107,18 +107,6 @@
             <artifactId>atp-auth-spring-boot-starter</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-security-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-webmvc</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-web</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>bcpkix-jdk15on</artifactId>
                     <groupId>org.bouncycastle</groupId>
                 </exclusion>

--- a/qubership-atp-tdm-backend/src/main/java/org/qubership/atp/tdm/controllers/TestDataController.java
+++ b/qubership-atp-tdm-backend/src/main/java/org/qubership/atp/tdm/controllers/TestDataController.java
@@ -18,7 +18,6 @@ package org.qubership.atp.tdm.controllers;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +56,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -144,7 +144,7 @@ public class TestDataController /* implements TestDataControllerApi */ {
                                                            @RequestParam List<UUID> environmentsIds,
                                                            @RequestParam String systemName,
                                                            @RequestParam String tableTitle,
-                                                           @RequestParam String query,
+                                                           @RequestPart String query,
                                                            @RequestParam Integer queryTimeout) {
         metricService.incrementInsertAction(projectId);
         return testDataService.importSqlTestData(projectId, environmentsIds, systemName,

--- a/qubership-atp-tdm-backend/src/main/java/org/qubership/atp/tdm/model/cleanup/cleaner/impl/SqlTestDataCleaner.java
+++ b/qubership-atp-tdm-backend/src/main/java/org/qubership/atp/tdm/model/cleanup/cleaner/impl/SqlTestDataCleaner.java
@@ -47,6 +47,7 @@ import org.slf4j.MDC;
 import liquibase.repackaged.net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import liquibase.repackaged.net.sf.jsqlparser.statement.Statement;
 import liquibase.repackaged.net.sf.jsqlparser.statement.select.Select;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -60,6 +61,7 @@ public class SqlTestDataCleaner implements TestDataCleaner {
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private int queryTimeout;
     private final Connection connection;
+    @Getter
     private String query;
 
     private final Encoder esapiEncoder = DefaultEncoder.getInstance();
@@ -77,45 +79,13 @@ public class SqlTestDataCleaner implements TestDataCleaner {
     @Override
     @Nonnull
     public List<Map<String, Object>> runCleanup(@Nonnull TestDataTable testDataTable) throws Exception {
-        Matcher m = COLUMN_PATTERN.matcher(query);
-        List<String> columns = new ArrayList<>();
-        String target;
-        String column;
-        int index;
-
-        log.info("Original cleanup query: {}", query);
-
-        /*
-            catch and replace column placeholders to build a PreparedStatement
-         */
-        while (m.find()) {
-            target = m.group();
-            column = m.group(1);
-            validateIdentifier(column);
-            index = TestDataUtils.getIndexHeaderColumnByName(testDataTable, column);
-            if (index < 0) {
-                throw new IllegalArgumentException("Column '" + column + "' doesn't exist");
-            }
-
-            query = query.replace(target, "?").trim().toUpperCase(Locale.ROOT);
-
-            String sanitizedColumnName = esapiEncoder.encodeForSQL(oracleCodec, column);
-            columns.add(sanitizedColumnName);
-        }
+        List<String> columns = collectParameterColumnsList(testDataTable);
 
         /*
             All column placeholders are replaced with '?' character, and columns list is populated.
             Let's parse the resulting query.
          */
-        Statement statement = CCJSqlParserUtil.parse(query);
-        if (statement instanceof Select) {
-            log.debug("This is a SELECT query.");
-        } else {
-            throw new SecurityException("Only SELECT statements are allowed!");
-        }
-        if (query.contains(";") || query.contains("--") || query.contains("/*")) {
-            throw new SecurityException("Potentially dangerous SQL syntax");
-        }
+        parseQuery();
 
         /*
             Check rows existence in the testDataTable.
@@ -168,6 +138,48 @@ public class SqlTestDataCleaner implements TestDataCleaner {
             }
             return rowsToBeDeleted;
         }
+    }
+
+    public List<String> collectParameterColumnsList(@Nonnull TestDataTable testDataTable) {
+        Matcher m = COLUMN_PATTERN.matcher(query);
+        List<String> columns = new ArrayList<>();
+        String target;
+        String column;
+        int index;
+
+        log.info("Original cleanup query: {}", query);
+
+        /*
+            catch and replace column placeholders to build a PreparedStatement
+         */
+        while (m.find()) {
+            target = m.group();
+            column = m.group(1);
+            validateIdentifier(column);
+            index = TestDataUtils.getIndexHeaderColumnByName(testDataTable, column);
+            if (index < 0) {
+                throw new IllegalArgumentException("Column '" + column + "' doesn't exist");
+            }
+
+            query = query.replace(target, "?").trim().toUpperCase(Locale.ROOT);
+
+            String sanitizedColumnName = esapiEncoder.encodeForSQL(oracleCodec, column);
+            columns.add(sanitizedColumnName);
+        }
+        return columns;
+    }
+
+    public boolean parseQuery() {
+        Statement statement = CCJSqlParserUtil.parse(query);
+        if (statement instanceof Select) {
+            log.debug("This is a SELECT query.");
+        } else {
+            throw new SecurityException("Only SELECT statements are allowed!");
+        }
+        if (query.contains(";") || query.contains("--") || query.contains("/*")) {
+            throw new SecurityException("Potentially dangerous SQL syntax");
+        }
+        return true;
     }
 
     private void validateIdentifier(String input) {

--- a/qubership-atp-tdm-backend/src/test/java/org/qubership/atp/tdm/service/impl/CleanupServiceTest.java
+++ b/qubership-atp-tdm-backend/src/test/java/org/qubership/atp/tdm/service/impl/CleanupServiceTest.java
@@ -16,6 +16,17 @@
 
 package org.qubership.atp.tdm.service.impl;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.qubership.atp.tdm.AbstractTestDataTest;
 import org.qubership.atp.tdm.exceptions.internal.TdmValidateCronException;
 import org.qubership.atp.tdm.model.TestDataTableCatalog;
@@ -23,19 +34,13 @@ import org.qubership.atp.tdm.model.cleanup.CleanupResults;
 import org.qubership.atp.tdm.model.cleanup.CleanupSettings;
 import org.qubership.atp.tdm.model.cleanup.CleanupType;
 import org.qubership.atp.tdm.model.cleanup.TestDataCleanupConfig;
+import org.qubership.atp.tdm.model.cleanup.cleaner.impl.SqlTestDataCleaner;
+import org.qubership.atp.tdm.model.table.TestDataTable;
+import org.qubership.atp.tdm.model.table.column.TestDataTableColumn;
+import org.qubership.atp.tdm.model.table.column.TestDataTableColumnIdentity;
 import org.qubership.atp.tdm.repo.CleanupConfigRepository;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-
-import java.util.*;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 public class CleanupServiceTest extends AbstractTestDataTest {
 
@@ -49,7 +54,6 @@ public class CleanupServiceTest extends AbstractTestDataTest {
     public void setUp() {
         when(environmentsService.getConnectionsSystemById(any())).thenReturn(connections);
     }
-
 
     @Test
     public void cleanupConfig_saveAndGetCleanup_returnNormalCleanup() throws Exception {
@@ -149,7 +153,6 @@ public class CleanupServiceTest extends AbstractTestDataTest {
         TestDataCleanupConfig updatedCleanupConfig = createSqlCleanupConfig(tableNameAtpQa, saveEnvList);
         TestDataCleanupConfig updatedCleanupConfigChanged = createSqlCleanupConfig(tableNameAtpQa, envForUpdate);
 
-
         catalogRepository.deleteByTableName(tableNameAtpUat);
         catalogRepository.deleteByTableName(tableNameAtpDev);
         catalogRepository.deleteByTableName(tableNameAtpQa);
@@ -180,7 +183,6 @@ public class CleanupServiceTest extends AbstractTestDataTest {
             cleanupRepository.deleteAll();
             catalogRepository.deleteByTableName(tableName);
         }
-
     }
 
     @Test
@@ -437,6 +439,55 @@ public class CleanupServiceTest extends AbstractTestDataTest {
         }
     }
 
+    @Test
+    public void checkSqlCleanupQueryParsing_validQuery() {
+        String sqlQuery = "select * from nc_objects where object_id = ${'CUSTOMER_ID'} and"
+                + " (select 24 * (sysdate - (INTERVAL '1' HOUR) - to_date(${'CREATED_WHEN'}, 'YYYY-MM-DD hh24:mi:ss'))"
+                + " from dual) < 24";
+        int queryTimeout = 10000;
+
+        List<String> expectedQueryColumns = new ArrayList<>();
+        expectedQueryColumns.add("CUSTOMER_ID");
+        expectedQueryColumns.add("CREATED_WHEN");
+
+        TestDataTable testDataTable = initTestDataTable();
+
+        SqlTestDataCleaner cleaner = new SqlTestDataCleaner(null, sqlQuery, queryTimeout);
+        List<String> actualQueryColumns = cleaner.collectParameterColumnsList(testDataTable);
+        Assertions.assertArrayEquals(expectedQueryColumns.toArray(), actualQueryColumns.toArray(),
+                "Query parameters placeholders don't match: " + expectedQueryColumns + " vs. "
+                        + actualQueryColumns);
+        boolean isValid = cleaner.parseQuery();
+        Assertions.assertTrue(isValid, "Query (after replacements) is assumed to be valid, but:\n"
+                + cleaner.getQuery());
+    }
+
+    @Test
+    public void checkSqlCleanupQueryParsing_validQuery_repeatedPlaceHolders() {
+        String sqlQuery = "select * from nc_objects where object_id = ${'CUSTOMER_ID'} "
+                + " and "
+                + " (select 24 * (sysdate - (INTERVAL '1' HOUR) - to_date(${'CREATED_WHEN'}, 'YYYY-MM-DD hh24:mi:ss'))"
+                + " from dual) < 24"
+                + " and "
+                + " parent_id != ${'CUSTOMER_ID'}";
+        int queryTimeout = 10000;
+
+        List<String> expectedQueryColumns = new ArrayList<>();
+        expectedQueryColumns.add("CUSTOMER_ID");
+        expectedQueryColumns.add("CREATED_WHEN");
+        expectedQueryColumns.add("CUSTOMER_ID");
+
+        TestDataTable testDataTable = initTestDataTable();
+
+        SqlTestDataCleaner cleaner = new SqlTestDataCleaner(null, sqlQuery, queryTimeout);
+        List<String> actualQueryColumns = cleaner.collectParameterColumnsList(testDataTable);
+        Assertions.assertArrayEquals(expectedQueryColumns.toArray(), actualQueryColumns.toArray(),
+                "Query parameters placeholders don't match: " + expectedQueryColumns + " vs. "
+                        + actualQueryColumns);
+        boolean isValid = cleaner.parseQuery();
+        Assertions.assertTrue(isValid, "Query (after replacements) is assumed to be valid, but:\n"
+                + cleaner.getQuery());
+    }
 
     private CleanupSettings createCleanupSettings(String cron, String tableName) {
         TestDataCleanupConfig cleanupConfig = new TestDataCleanupConfig();
@@ -453,5 +504,24 @@ public class CleanupServiceTest extends AbstractTestDataTest {
         cleanupSettings.setTableName(tableName);
         cleanupSettings.setEnvironmentsList(Collections.singletonList(UUID.randomUUID()));
         return cleanupSettings;
+    }
+
+    private TestDataTableColumn createColumn(String tableName, String columnName) {
+        TestDataTableColumnIdentity columnIdentity = new TestDataTableColumnIdentity();
+        columnIdentity.setTableName(tableName);
+        columnIdentity.setColumnName(columnName);
+        return new TestDataTableColumn(columnIdentity);
+    }
+
+    private TestDataTable initTestDataTable() {
+        TestDataTable testDataTable = new TestDataTable();
+        testDataTable.setName("tdm_test1");
+        testDataTable.setTitle("TDM Test 1");
+        List<TestDataTableColumn> tableColumns = new ArrayList<>();
+        tableColumns.add(createColumn("tdm_test1", "CUSTOMER_ID"));
+        tableColumns.add(createColumn("tdm_test1", "CUSTOMER_TYPE"));
+        tableColumns.add(createColumn("tdm_test1", "CREATED_WHEN"));
+        testDataTable.setColumns(tableColumns);
+        return testDataTable;
     }
 }

--- a/qubership-atp-tdm-env-configurator/pom.xml
+++ b/qubership-atp-tdm-env-configurator/pom.xml
@@ -90,10 +90,6 @@
             <artifactId>atp-auth-spring-boot-starter</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-webflux</artifactId>
-                </exclusion>
-                <exclusion>
                     <artifactId>guava</artifactId>
                     <groupId>com.google.guava</groupId>
                 </exclusion>
@@ -123,12 +119,6 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>1.7.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-webmvc</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION



<!-- start messages -->
### Commit messages:
[Bogdan-Bairamov](https://github.com/Netcracker/qubership-testing-platform-tdm/commit/1c6e1b0b1e36c212732e3da492b9f89e51e5c0ce) fix: Fix sql import with large query (Remove spring-webmvc and spring-web dependencies from exclusion)
[Bogdan-Bairamov](https://github.com/Netcracker/qubership-testing-platform-tdm/commit/53ba5c96356a62c50c842949e6f97fc2d7e63611) fix: Fix sql import with large query (Replace RequestParam annotation to RequestPart for query param)
[kagw95](https://github.com/Netcracker/qubership-testing-platform-tdm/commit/71cd34604b8b717d4e676394edb849f7f35c2e74) fix: SqlTestDataCleaner#runCleanup method - incorrect parse algorithm is fixed (old behavior: only one query parameter was processed properly).
[kagw95](https://github.com/Netcracker/qubership-testing-platform-tdm/commit/1ae091cbe3c6fa493836603a612fb134c871f1f5) refactor: SqlTestDataCleaner#runCleanup method is refactored in order to simplify testing. Tests of parser are added to CleanupServiceTest.
<!-- end messages -->


